### PR TITLE
FIX: ble devices not registering online

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSaveMode": "modificationsIfAvailable"
+}

--- a/tuya_sharing/device.py
+++ b/tuya_sharing/device.py
@@ -157,6 +157,15 @@ class DeviceRepository:
                     support_local = False
                     break
                 # statusFormat valueDesc、valueType,enumMappingMap,pid
+
+                # Issue: as at 2024-02-13 the `enumMappingMap` for dpId==92 is not handling the format of data being received in CapWords format ie  `True` and `False` as apposed to `true` and `false`
+                # # workaround ----------------------------- start
+                # for the following dpId and enumMappingMap
+                if dp_status_relation["dpId"]==92 and dp_status_relation["enumMappingMap"]=={'false': {'code': 'pir', 'value': 'none'}, 'true': {'code': 'pir', 'value': 'pir'}}:
+                    # change keys to CapWords format
+                    dp_status_relation["enumMappingMap"]={'False': {'code': 'pir', 'value': 'none'}, 'True': {'code': 'pir', 'value': 'pir'}}
+                # # workaround ----------------------------- end
+
                 dp_id_map[dp_status_relation["dpId"]] = {
                     "value_convert": dp_status_relation["valueConvert"],
                     "status_code": dp_status_relation["statusCode"],

--- a/tuya_sharing/manager.py
+++ b/tuya_sharing/manager.py
@@ -146,6 +146,11 @@ class Manager:
         if not device:
             return
         logger.debug(f"mq _on_device_report-> {status}")
+
+        # As the protocol is PROTOCOL_DEVICE_REPORT there does not appear to be `data['bizCode']`
+        # As we are getting a report declare this device online
+        device.online=True
+
         if device.support_local:
             for item in status:
                 if "dpId" in item and "value" in item:


### PR DESCRIPTION
FIX: ble devices not registering online
WIP: ble pir enumMappingMap workaround 

The Online status is determined by a protocol ==4 report being received

as per #8 the workaround handle `dpId==92` and the API returning a  `dp_status_relation["enumMappingMap"]=={'false': {'code': 'pir', 'value': 'none'}, 'true': {'code': 'pir', 'value': 'pir'}}`
This is probably best handled by an update to `tuya_sharing/strategy_repo/enum_.py` I dont have testing capabilities and there are not unittests hence i am just modifying the `enumMappingMap` to make the existing enum strategy  to work

See https://github.com/tuya/tuya-device-sharing-sdk/issues/8