### PR TITLE
Include list of updated status properties in SharingDeviceListener.update_device

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ With diversified devices and industries, Tuya IoT Development Platform opens bas
 
 ## Release Note
 
-| version | Description             |
-|---------|-------------------------|
-| 0.1.8   | fix topic error         |
-| 0.1.9   | fix mq link id          |
-| 0.2.0   | MQTT bulk subscription  |
+| version | Description                                            |
+| ------- | ------------------------------------------------------ |
+| 0.1.8   | fix topic error                                        |
+| 0.1.9   | fix mq link id                                         |
+| 0.2.0   | MQTT bulk subscription                                 |
+| 0.2.1   | add updated_status_properties to SharingDeviceListener |
 
 ## Installation
 

--- a/tuya_sharing/version.py
+++ b/tuya_sharing/version.py
@@ -1,3 +1,3 @@
 """smartlife device sharing sdk version."""
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"


### PR DESCRIPTION
In the current form, no information what has been updated is shared with SharingDeviceListener. This makes it impossible to implement event-based integrations as required by switches for instance as it is unclear which state the device reported if it didn't change. 

As an example, a switch such as the one depicted below which implements the instruction set described at https://developer.tuya.com/en/docs/iot/s?id=Kbeoa9fkv6brp can't be implemented as it is impossible to detect events on `switch_mode1` if the user just keeps clicking (`click` value) instead of alternating between `click` and `press`.

![switch](https://github.com/user-attachments/assets/b703f7ae-90aa-48e9-aec6-685db564a573)


