### PR TITLE
Handle exception in device_report processing

### DIFF
--- a/tuya_sharing/manager.py
+++ b/tuya_sharing/manager.py
@@ -158,18 +158,21 @@ class Manager:
             for item in status:
                 # [{'dpId': 1, 't': 1752456620499, 'value': 120}]
                 if "dpId" in item and "value" in item:
-                    dp_id_item = device.local_strategy[item["dpId"]]
-                    strategy_name = dp_id_item["value_convert"]
-                    config_item = dp_id_item["config_item"]
-                    dp_item = (dp_id_item["status_code"], item["value"])
-                    logger.debug(
-                        f"mq _on_device_report before strategy convert strategy_name={strategy_name},dp_item={dp_item},config_item={config_item}")
-                    code, value = strategy.convert(strategy_name, dp_item, config_item)
-                    logger.debug(f"mq _on_device_report after strategy convert code={code},value={value}")
-                    device.status[code] = value
-                    updated_status_properties.append(code)
-                    if t := item.get("t"):
-                        dp_timestamps[code] = t
+                    try:
+                        dp_id_item = device.local_strategy[item["dpId"]]
+                        strategy_name = dp_id_item["value_convert"]
+                        config_item = dp_id_item["config_item"]
+                        dp_item = (dp_id_item["status_code"], item["value"])
+                        logger.debug(
+                            f"mq _on_device_report before strategy convert strategy_name={strategy_name},dp_item={dp_item},config_item={config_item}")
+                        code, value = strategy.convert(strategy_name, dp_item, config_item)
+                        logger.debug(f"mq _on_device_report after strategy convert code={code},value={value}")
+                        device.status[code] = value
+                        updated_status_properties.append(code)
+                        if t := item.get("t"):
+                            dp_timestamps[code] = t
+                    except Exception as e:
+                        logger.error(f"mq _on_device_report exception {e}. No local strategy for {item['dpId']}?")
         else:
             for item in status:
                 if "code" in item and "value" in item:


### PR DESCRIPTION
Sometime in device_report can be more than one changed item and sometime some of those items may contain "unexpected" (at least not listed in local_strategy) dpId. With original implementation this raise an exception which is handled on higher level function, but that leave remaining dpId's in the list unprocessed and therefore their states remain unchanged.
I propose to wrap handling of individual dpId in try..except clause - in such way we will skip "unexpected" dpIds, but process all known.