### PR TITLE
Fix compatibility with paho-client>=v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ With diversified devices and industries, Tuya IoT Development Platform opens bas
 | 0.1.9   | fix mq link id                                         |
 | 0.2.0   | MQTT bulk subscription                                 |
 | 0.2.1   | add updated_status_properties to SharingDeviceListener |
+| 0.2.2   | fix paho-mqtt dependency                               |
 
 ## Installation
 
@@ -62,4 +63,3 @@ You can provide feedback on your issue via **Github Issue**.
 ## License
 
 **tuya-device-sharing-sdk** is available under the MIT license. Please see the [LICENSE](./LICENSE) file for more info.
->>>>>>> main

--- a/tuya_sharing/mq.py
+++ b/tuya_sharing/mq.py
@@ -140,7 +140,7 @@ class SharingMQ(threading.Thread):
         self.client = mqttc
 
     def _start(self, mq_config: SharingMQConfig) -> mqtt.Client:
-        mqttc = mqtt.Client(mq_config.client_id)
+        mqttc = mqtt.Client(client_id=mq_config.client_id)
         mqttc.username_pw_set(mq_config.username, mq_config.password)
         mqttc.user_data_set({"mqConfig": mq_config})
         mqttc.on_connect = self._on_connect

--- a/tuya_sharing/version.py
+++ b/tuya_sharing/version.py
@@ -1,3 +1,3 @@
 """smartlife device sharing sdk version."""
 
-VERSION = "0.2.1"
+VERSION = "0.2.2"


### PR DESCRIPTION
Version 2.x of the `paho-mqtt` MQTT client does not allow the `client_id` as first positional parameter.
As the dependencies do not pin the `paho_mqtt` client, it is expected that the code should work with the latest version of the the `paho-mqtt` library.

Home Assistant now depends on a work-a-round till this is fixed, see:
https://github.com/home-assistant/core/pull/139518

Related: https://github.com/home-assistant/core/issues/139377
