### PR TITLE
Mark device as online on PROTOCOL_DEVICE_REPORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ With diversified devices and industries, Tuya IoT Development Platform opens bas
 | 0.2.1   | add updated_status_properties to SharingDeviceListener |
 | 0.2.2   | add timestamp to SharingDeviceListener                 |
 | 0.2.3   | fix paho-mqtt dependency                               |
-| 0.2.4   | fix asbtract decorator                                 |
+| 0.2.4   | fix abstract decorator                                 |
+| 0.2.5   | mark device as online on PROTOCOL_DEVICE_REPORT        |
 
 ## Installation
 

--- a/tuya_sharing/manager.py
+++ b/tuya_sharing/manager.py
@@ -151,6 +151,11 @@ class Manager:
         if not device:
             return
         logger.debug(f"mq _on_device_report-> {status}")
+
+        # As the protocol is PROTOCOL_DEVICE_REPORT there does not appear to be `data['bizCode']`
+        # As we are getting a report declare this device online
+        device.online = True
+
         updated_status_properties = []
         dp_timestamps = {}
         value = None


### PR DESCRIPTION
BLE sensors remain unavailable in Home Assistant, with no state change or battery voltage indication. Enabling the debug logging show that the integration is receiving the reports from the sensors.

Linked to #8 (and partially extracted from #9)