### PR TITLE
fix boolean issue in enum_.py

### DIFF
--- a/tuya_sharing/strategy_repo/enum_.py
+++ b/tuya_sharing/strategy_repo/enum_.py
@@ -18,12 +18,16 @@ def convert(dp_item: tuple, config_item: dict = None) -> tuple:
     status_key, _ = json.loads(config_item["statusFormat"]).popitem()
     enum_mappings = config_item["enumMappingMap"]
     status_value = None
-    if str(dp_value) in enum_mappings and "value" in enum_mappings[str(dp_value)]:
-        status_value = enum_mappings[str(dp_value)]["value"]
+
+    key_raw = str(dp_value)
+    key_lc = key_raw.lower()
+
+    if key_raw in enum_mappings and "value" in enum_mappings[key_raw]:
+        status_value = enum_mappings[key_raw]["value"]
+    elif key_lc in enum_mappings and "value" in enum_mappings[key_lc]:
+        status_value = enum_mappings[key_lc]["value"]
+
     if status_value is None:
         status_value = convert_default_value(config_item)
+
     return status_key, status_value
-
-
-
-


### PR DESCRIPTION
### Fix enum mapping when dp_value is boolean but enumMappingMap keys are lowercase strings

#### Problem
`tuya_sharing/strategy_repo/enum_.py` currently uses `str(dp_value)` as the lookup key into `enumMappingMap`.
When dp_value is a Python bool, `str(False)` -> "False" and `str(True)` -> "True" (capitalized),
but many device configs use lowercase mapping keys "false"/"true".

This causes enum mapping to fail and the converter falls back to `convert_default_value`, which can
leave state stuck (e.g. PIR motion never clears when clear event arrives as False).

#### Change
- Try lookup with the raw string key first (backward compatible)
- If not found, try a lowercase variant (`key_raw.lower()`)

#### Repro (example mapping)
enumMappingMap:
- "true" -> {"value": "pir"}
- "false" -> {"value": "none"}

dp_value=False should map to "none" (previously did not).
