### PR TITLE
feat(home): add query_room_by_device to query a device's room

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ With diversified devices and industries, Tuya IoT Development Platform opens bas
 	- send_commands
 - HomeRepository
 	- query_homes
+	- query_room_by_device
 - SceneRepository
 	- query_scenes
 	- trigger_scene
@@ -58,6 +59,7 @@ With diversified devices and industries, Tuya IoT Development Platform opens bas
 | 0.2.8   | Add report_type to device status  #51                  |
 | 0.2.9   | Fix incorrect type hint in DeviceFunction #44 <br/>Add pre-commit workflow #46 <br/>Apply ruff format #47 |
 | 0.2.10  | Make enum mapping lookups case-insensitive #55 <br/>Add ruff-check to pre-commit #56 <br/>Add ApiRequestException for failed API responses #58 <br/>Fix 0.2.9 changelog formatting #59 |
+| 0.2.11  | Add query_room_by_device to query the room a device belongs to |
 
 ## Installation
 

--- a/tuya_sharing/home.py
+++ b/tuya_sharing/home.py
@@ -9,6 +9,13 @@ class SmartLifeHome:
         self.name = name
 
 
+class SmartLifeRoom:
+    def __init__(self, id: str, name: str, display_order: int = 0):
+        self.id = id
+        self.name = name
+        self.display_order = display_order
+
+
 class HomeRepository:
     def __init__(self, customer_api: CustomerApi):
         self.api = customer_api
@@ -24,3 +31,15 @@ class HomeRepository:
             return _homes
 
         return []
+
+    def query_room_by_device(self, device_id: str) -> SmartLifeRoom | None:
+        response = self.api.get(f"/v1.0/cloud/life/ha/{device_id}/room")
+
+        if response.get("success", False):
+            room = response.get("result")
+            if room:
+                return SmartLifeRoom(
+                    str(room["id"]), room["name"], room.get("displayOrder", 0)
+                )
+
+        return None

--- a/tuya_sharing/manager.py
+++ b/tuya_sharing/manager.py
@@ -4,7 +4,7 @@ from typing import Any, Literal, Optional
 
 from .customerapi import CustomerApi, CustomerTokenInfo, SharingTokenListener
 from .device import DeviceRepository, CustomerDevice
-from .home import HomeRepository, SmartLifeHome
+from .home import HomeRepository, SmartLifeHome, SmartLifeRoom
 from .scenes import SceneRepository
 from .user import UserRepository
 from .strategy import strategy
@@ -97,6 +97,9 @@ class Manager:
 
     def send_commands(self, device_id: str, commands: list[dict[str, Any]]):
         return self.device_repository.send_commands(device_id, commands)
+
+    def query_room_by_device(self, device_id: str) -> Optional[SmartLifeRoom]:
+        return self.home_repository.query_room_by_device(device_id)
 
     def get_device_stream_allocate(
         self, device_id: str, stream_type: Literal["flv", "hls", "rtmp", "rtsp"]

--- a/tuya_sharing/version.py
+++ b/tuya_sharing/version.py
@@ -1,3 +1,3 @@
 """smartlife device sharing sdk version."""
 
-VERSION = "0.2.10"
+VERSION = "0.2.11"


### PR DESCRIPTION
Add HomeRepository.query_room_by_device and expose it via Manager to query the room a device belongs to through
GET /v1.0/cloud/life/ha/{device_id}/room. A device belongs to a single room, so it returns one SmartLifeRoom (or None when the device has no room, i.e. result is {} or null). Bump version to 0.2.11 and update README API list and release notes.