### PR TITLE
fix(customerapi): prevent sign-invalid loop when access token expires

### DIFF
--- a/tuya_sharing/customerapi.py
+++ b/tuya_sharing/customerapi.py
@@ -140,48 +140,33 @@ class CustomerApi:
 
         self.refresh_token = True
         try:
-            for attempt in range(3):
-                try:
-                    # When the access_token is already expired the server cannot
-                    # validate the X-token signature component and returns
-                    # "sign invalid (-9999999)".  Omit it so the sign is built
-                    # from the refresh_token alone, which is what the endpoint
-                    # actually requires.
-                    saved_access_token = self.token_info.access_token
-                    token_is_expired = expired_time <= now
-                    if token_is_expired:
-                        self.token_info.access_token = ""
-                    try:
-                        response = self.get("/v1.0/m/token/" + self.token_info.refresh_token)
-                    finally:
-                        if token_is_expired and not self.token_info.access_token:
-                            self.token_info.access_token = saved_access_token
+            # X-token is not required on a refresh call (per API docs) and
+            # including it can cause sign-invalid on some server versions.
+            # Always omit it so the signature is built from refresh_token alone.
+            saved_access_token = self.token_info.access_token
+            self.token_info.access_token = ""
+            try:
+                response = self.get("/v1.0/m/token/" + self.token_info.refresh_token)
+            finally:
+                if not self.token_info.access_token:
+                    self.token_info.access_token = saved_access_token
 
-                    if response and response.get("success"):
-                        result = response.get("result", {})
-                        token_info = {
-                            "t": response["t"],
-                            "expire_time": result["expireTime"],
-                            "uid": result["uid"],
-                            "access_token": result["accessToken"],
-                            "refresh_token": result["refreshToken"],
-                        }
-                        self.token_info = CustomerTokenInfo(token_info)
-                        if self.token_listener is not None:
-                            self.token_listener.update_token(token_info)
-                        return
-                    else:
-                        logger.error(
-                            "token refresh attempt %d/3 returned no success", attempt + 1
-                        )
-                except Exception as e:
-                    if "1010" in str(e):
-                        logger.error("token refresh: permanent failure (token expired/invalid), skipping retries: %s", e)
-                        return
-                    logger.error("token refresh attempt %d/3 failed: %s", attempt + 1, e)
-                if attempt < 2:
-                    time.sleep(30)
-            logger.error("token refresh failed after 3 attempts")
+            if response and response.get("success"):
+                result = response.get("result", {})
+                token_info = {
+                    "t": response["t"],
+                    "expire_time": result["expireTime"],
+                    "uid": result["uid"],
+                    "access_token": result["accessToken"],
+                    "refresh_token": result["refreshToken"],
+                }
+                self.token_info = CustomerTokenInfo(token_info)
+                if self.token_listener is not None:
+                    self.token_listener.update_token(token_info)
+            else:
+                logger.error("token refresh failed")
+        except Exception as e:
+            logger.error("token refresh failed: %s", e)
         finally:
             self.refresh_token = False
 

--- a/tuya_sharing/customerapi.py
+++ b/tuya_sharing/customerapi.py
@@ -140,22 +140,31 @@ class CustomerApi:
 
         self.refresh_token = True
         try:
-            response = self.get("/v1.0/m/token/" + self.token_info.refresh_token)
-
-            if response.get("success"):
-                result = response.get("result", {})
-                token_info = {
-                    "t": response["t"],
-                    "expire_time": result["expireTime"],
-                    "uid": result["uid"],
-                    "access_token": result["accessToken"],
-                    "refresh_token": result["refreshToken"],
-                }
-                self.token_info = CustomerTokenInfo(token_info)
-                if self.token_listener is not None:
-                    self.token_listener.update_token(token_info)
-        except Exception as e:
-            logger.error("net work error = %s", e)
+            for attempt in range(3):
+                try:
+                    response = self.get("/v1.0/m/token/" + self.token_info.refresh_token)
+                    if response and response.get("success"):
+                        result = response.get("result", {})
+                        token_info = {
+                            "t": response["t"],
+                            "expire_time": result["expireTime"],
+                            "uid": result["uid"],
+                            "access_token": result["accessToken"],
+                            "refresh_token": result["refreshToken"],
+                        }
+                        self.token_info = CustomerTokenInfo(token_info)
+                        if self.token_listener is not None:
+                            self.token_listener.update_token(token_info)
+                        return
+                    else:
+                        logger.error(
+                            "token refresh attempt %d/3 returned no success", attempt + 1
+                        )
+                except Exception as e:
+                    logger.error("token refresh attempt %d/3 failed: %s", attempt + 1, e)
+                if attempt < 2:
+                    time.sleep(30)
+            logger.error("token refresh failed after 3 attempts")
         finally:
             self.refresh_token = False
 

--- a/tuya_sharing/customerapi.py
+++ b/tuya_sharing/customerapi.py
@@ -1,12 +1,9 @@
 """Customer API."""
-
 from __future__ import annotations
 
 from typing import Any
 import requests
-from .const import DEFAULT_TIMEOUT
 from .customerlogging import logger
-from .exceptions import ApiRequestException
 import json
 import hmac
 import hashlib
@@ -17,6 +14,7 @@ import uuid
 from abc import ABCMeta
 
 import time
+import threading
 
 
 class CustomerTokenInfo:
@@ -30,7 +28,8 @@ class CustomerTokenInfo:
 
     def __init__(self, token_info: dict[str, Any] = None):
         self.expire_time = (
-            token_info.get("t", 0) + token_info.get("expire_time", 0) * 1000
+                token_info.get("t", 0)
+                + token_info.get("expire_time", 0) * 1000
         )
         self.uid = token_info.get("uid", "")
         self.access_token = token_info.get("access_token", "")
@@ -38,13 +37,14 @@ class CustomerTokenInfo:
 
 
 class CustomerApi:
+
     def __init__(
-        self,
-        token_info: CustomerTokenInfo,
-        client_id: str,
-        user_code: str,
-        end_point: str,
-        listener: SharingTokenListener,
+            self,
+            token_info: CustomerTokenInfo,
+            client_id: str,
+            user_code: str,
+            end_point: str,
+            listener: SharingTokenListener
     ):
         self.session = requests.session()
         self.token_info = token_info
@@ -53,21 +53,25 @@ class CustomerApi:
         self.endpoint = end_point
         self.refresh_token = False
         self.token_listener = listener
+        self._refresh_lock = threading.Lock()
+        self._refreshing = threading.local()
 
     def __request(
-        self,
-        method: str,
-        path: str,
-        params: dict[str, Any] | None = None,
-        body: dict[str, Any] | None = None,
+            self,
+            method: str,
+            path: str,
+            params: dict[str, Any] | None = None,
+            body: dict[str, Any] | None = None,
+            skip_token: bool = False,
     ) -> dict[str, Any] | None:
+
         self.refresh_access_token_if_need()
 
         rid = str(uuid.uuid4())
         sid = ""
         md5 = hashlib.md5()
         rid_refresh_token = rid + self.token_info.refresh_token
-        md5.update(rid_refresh_token.encode("utf-8"))
+        md5.update(rid_refresh_token.encode('utf-8'))
         hash_key = md5.hexdigest()
         secret = _secret_generating(rid, sid, hash_key)
 
@@ -75,13 +79,17 @@ class CustomerApi:
         if params is not None and len(params.keys()) > 0:
             query_encdata = _form_to_json(params)
             query_encdata = _aes_gcm_encrypt(query_encdata, secret)
-            params = {"encdata": query_encdata}
+            params = {
+                "encdata": query_encdata
+            }
             query_encdata = str(query_encdata, encoding="utf8")
         body_encdata = ""
         if body is not None and len(body.keys()) > 0:
             body_encdata = _form_to_json(body)
             body_encdata = _aes_gcm_encrypt(body_encdata, secret)
-            body = {"encdata": str(body_encdata, encoding="utf8")}
+            body = {
+                "encdata": str(body_encdata, encoding="utf8")
+            }
             body_encdata = str(body_encdata, encoding="utf8")
 
         t = int(time.time() * 1000)
@@ -91,19 +99,17 @@ class CustomerApi:
             "X-sid": sid,
             "X-time": str(t),
         }
-        if self.token_info is not None and len(self.token_info.access_token) > 0:
+        if not skip_token and self.token_info is not None and len(self.token_info.access_token) > 0:
             headers["X-token"] = self.token_info.access_token
 
-        sign = _restful_sign(hash_key, query_encdata, body_encdata, headers)
+        sign = _restful_sign(hash_key,
+                             query_encdata,
+                             body_encdata,
+                             headers)
         headers["X-sign"] = sign
 
         response = self.session.request(
-            method,
-            self.endpoint + path,
-            params=params,
-            json=body,
-            headers=headers,
-            timeout=DEFAULT_TIMEOUT,
+            method, self.endpoint + path, params=params, json=body, headers=headers
         )
 
         if response.ok is False:
@@ -116,41 +122,42 @@ class CustomerApi:
         logger.debug("response before decrypt ret = %s", ret)
 
         if not ret.get("success"):
-            raise ApiRequestException(error_code=ret["code"], error_message=ret["msg"])
+            raise Exception(f"network error:({ret['code']}) {ret['msg']}")
 
-        if ret.get("result"):
-            result = _aex_gcm_decrypt(ret.get("result"), secret)
-            try:
-                ret["result"] = json.loads(result)
-            except json.decoder.JSONDecodeError:
-                ret["result"] = result
+        result = _aex_gcm_decrypt(ret.get("result"), secret)
+        try:
+            ret["result"] = json.loads(result)
+        except json.decoder.JSONDecodeError:
+            ret["result"] = result
 
         logger.debug("response ret = %s", ret)
         return ret
 
     def refresh_access_token_if_need(self):
-        if self.refresh_token:
+        # Guard against recursive calls: get() -> __request() -> here again
+        # on the same thread. The lock below serialises across threads; this
+        # local flag prevents the same thread from deadlocking on itself.
+        if getattr(self._refreshing, "active", False):
             return
 
-        now = int(time.time() * 1000)
-        expired_time = self.token_info.expire_time
+        with self._refresh_lock:
+            # Re-check inside the lock: another thread may have just refreshed.
+            now = int(time.time() * 1000)
+            expired_time = self.token_info.expire_time
+            remaining_sec = (expired_time - now) // 1000
+            logger.debug("refresh_access_token_if_need: token remaining=%ds", remaining_sec)
 
-        if expired_time - 30 * 60 * 1000 > now:  # refresh 30 min before expiry
-            return
+            if expired_time - 30 * 60 * 1000 > now:  # 30min proactive window
+                return
 
-        self.refresh_token = True
+        logger.debug("refresh_access_token_if_need: window open, attempting refresh")
+        self._refreshing.active = True
         try:
-            # X-token is not required on a refresh call (per API docs) and
-            # including it can cause sign-invalid on some server versions.
-            # Always omit it so the signature is built from refresh_token alone.
-            saved_access_token = self.token_info.access_token
-            self.token_info.access_token = ""
-            try:
-                response = self.get("/v1.0/m/token/" + self.token_info.refresh_token)
-            finally:
-                if not self.token_info.access_token:
-                    self.token_info.access_token = saved_access_token
-
+            # skip_token=True: X-token is not required on a refresh call (per
+            # API docs) and including it can cause sign-invalid on some server
+            # versions. Pass the flag so __request omits it cleanly without
+            # mutating shared state.
+            response = self.get("/v1.0/m/token/" + self.token_info.refresh_token, skip_token=True)
             if response and response.get("success"):
                 result = response.get("result", {})
                 token_info = {
@@ -158,7 +165,7 @@ class CustomerApi:
                     "expire_time": result["expireTime"],
                     "uid": result["uid"],
                     "access_token": result["accessToken"],
-                    "refresh_token": result["refreshToken"],
+                    "refresh_token": result["refreshToken"]
                 }
                 self.token_info = CustomerTokenInfo(token_info)
                 if self.token_listener is not None:
@@ -168,9 +175,9 @@ class CustomerApi:
         except Exception as e:
             logger.error("token refresh failed: %s", e)
         finally:
-            self.refresh_token = False
+            self._refreshing.active = False
 
-    def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    def get(self, path: str, params: dict[str, Any] | None = None, skip_token: bool = False) -> dict[str, Any]:
         """Http Get.
 
         Requests the server to return specified resources.
@@ -178,18 +185,15 @@ class CustomerApi:
         Args:
             path (str): api path
             params (map): request parameter
+            skip_token (bool): if True, omit X-token from request headers
 
         Returns:
             response: response body
         """
-        return self.__request("GET", path, params, None)
+        return self.__request("GET", path, params, None, skip_token=skip_token)
 
-    def post(
-        self,
-        path: str,
-        params: dict[str, Any] | None = None,
-        body: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
+    def post(self, path: str, params: dict[str, Any] | None = None, body: dict[str, Any] | None = None) -> dict[
+        str, Any]:
         """Http Post.
 
         Requests the server to update specified resources.
@@ -243,14 +247,14 @@ def _random_nonce(e=32):
 
 
 def _form_to_json(content: dict[str, Any] | None = None) -> str:
-    return json.dumps(content, separators=(",", ":"))
+    return json.dumps(content, separators=(',', ':'))
 
 
 def _aes_gcm_encrypt(raw_data: str, secret: str):
     nonce = _random_nonce(12)
-    raw_data = raw_data.encode("utf-8")
-    secret = secret.encode("utf-8")
-    nonce = nonce.encode("utf-8")
+    raw_data = raw_data.encode('utf-8')
+    secret = secret.encode('utf-8')
+    nonce = nonce.encode('utf-8')
     cipher = AESGCM(secret)
     ciphertext = cipher.encrypt(nonce, raw_data, None)
 
@@ -261,7 +265,7 @@ def _aex_gcm_decrypt(cipher_data: str, secret: str) -> str:
     cipher_data = base64.b64decode(cipher_data)
     nonce = cipher_data[:12]
     cipher_text = cipher_data[12:]
-    secret = secret.encode("utf-8")
+    secret = secret.encode('utf-8')
     cipher = AESGCM(secret)
     decrypt = cipher.decrypt(nonce, cipher_text, None)
     return str(decrypt, encoding="utf8")
@@ -281,9 +285,9 @@ def _secret_generating(rid, sid, hash_key) -> str:
         message += ecode
 
     if isinstance(message, str):
-        message = message.encode("utf-8")
+        message = message.encode('utf-8')
     if isinstance(rid, str):
-        rid = rid.encode("utf-8")
+        rid = rid.encode('utf-8')
 
     checksum = hmac.new(rid, message, hashlib.sha256)
     byte_temp = checksum.digest()
@@ -292,9 +296,7 @@ def _secret_generating(rid, sid, hash_key) -> str:
     return secret[:16]
 
 
-def _restful_sign(
-    hash_key: str, query_encdata: str, body_encdata: str, data: dict[str, Any]
-) -> str:
+def _restful_sign(hash_key: str, query_encdata: str, body_encdata: str, data: dict[str, Any]) -> str:
     headers = ["X-appKey", "X-requestId", "X-sid", "X-time", "X-token"]
     header_sign_str = ""
     for item in headers:
@@ -309,8 +311,8 @@ def _restful_sign(
     if body_encdata is not None and body_encdata != "":
         sign_str += body_encdata
 
-    sign_str = bytes(sign_str, "utf-8")
-    hash_key = bytes(hash_key, "utf-8")
+    sign_str = bytes(sign_str, 'utf-8')
+    hash_key = bytes(hash_key, 'utf-8')
 
     hash_value = hmac.new(hash_key, sign_str, hashlib.sha256)
     return hash_value.hexdigest()
@@ -318,5 +320,6 @@ def _restful_sign(
 
 class SharingTokenListener(metaclass=ABCMeta):
     def update_token(self, token_info: dict[str, Any]):
-        """Update token."""
+        """Update token.
+        """
         pass

--- a/tuya_sharing/customerapi.py
+++ b/tuya_sharing/customerapi.py
@@ -175,6 +175,9 @@ class CustomerApi:
                             "token refresh attempt %d/3 returned no success", attempt + 1
                         )
                 except Exception as e:
+                    if "1010" in str(e):
+                        logger.error("token refresh: permanent failure (token expired/invalid), skipping retries: %s", e)
+                        return
                     logger.error("token refresh attempt %d/3 failed: %s", attempt + 1, e)
                 if attempt < 2:
                     time.sleep(30)

--- a/tuya_sharing/customerapi.py
+++ b/tuya_sharing/customerapi.py
@@ -135,14 +135,28 @@ class CustomerApi:
         now = int(time.time() * 1000)
         expired_time = self.token_info.expire_time
 
-        if expired_time - 60 * 1000 > now:  # 1min
+        if expired_time - 30 * 60 * 1000 > now:  # refresh 30 min before expiry
             return
 
         self.refresh_token = True
         try:
             for attempt in range(3):
                 try:
-                    response = self.get("/v1.0/m/token/" + self.token_info.refresh_token)
+                    # When the access_token is already expired the server cannot
+                    # validate the X-token signature component and returns
+                    # "sign invalid (-9999999)".  Omit it so the sign is built
+                    # from the refresh_token alone, which is what the endpoint
+                    # actually requires.
+                    saved_access_token = self.token_info.access_token
+                    token_is_expired = expired_time <= now
+                    if token_is_expired:
+                        self.token_info.access_token = ""
+                    try:
+                        response = self.get("/v1.0/m/token/" + self.token_info.refresh_token)
+                    finally:
+                        if token_is_expired and not self.token_info.access_token:
+                            self.token_info.access_token = saved_access_token
+
                     if response and response.get("success"):
                         result = response.get("result", {})
                         token_info = {

--- a/tuya_sharing/customerapi.py
+++ b/tuya_sharing/customerapi.py
@@ -150,32 +150,32 @@ class CustomerApi:
             if expired_time - 30 * 60 * 1000 > now:  # 30min proactive window
                 return
 
-        logger.debug("refresh_access_token_if_need: window open, attempting refresh")
-        self._refreshing.active = True
-        try:
-            # skip_token=True: X-token is not required on a refresh call (per
-            # API docs) and including it can cause sign-invalid on some server
-            # versions. Pass the flag so __request omits it cleanly without
-            # mutating shared state.
-            response = self.get("/v1.0/m/token/" + self.token_info.refresh_token, skip_token=True)
-            if response and response.get("success"):
-                result = response.get("result", {})
-                token_info = {
-                    "t": response["t"],
-                    "expire_time": result["expireTime"],
-                    "uid": result["uid"],
-                    "access_token": result["accessToken"],
-                    "refresh_token": result["refreshToken"]
-                }
-                self.token_info = CustomerTokenInfo(token_info)
-                if self.token_listener is not None:
-                    self.token_listener.update_token(token_info)
-            else:
-                logger.error("token refresh failed")
-        except Exception as e:
-            logger.error("token refresh failed: %s", e)
-        finally:
-            self._refreshing.active = False
+            logger.debug("refresh_access_token_if_need: window open, attempting refresh")
+            self._refreshing.active = True
+            try:
+                # skip_token=True: X-token is not required on a refresh call (per
+                # API docs) and including it can cause sign-invalid on some server
+                # versions. Pass the flag so __request omits it cleanly without
+                # mutating shared state.
+                response = self.get("/v1.0/m/token/" + self.token_info.refresh_token, skip_token=True)
+                if response and response.get("success"):
+                    result = response.get("result", {})
+                    token_info = {
+                        "t": response["t"],
+                        "expire_time": result["expireTime"],
+                        "uid": result["uid"],
+                        "access_token": result["accessToken"],
+                        "refresh_token": result["refreshToken"]
+                    }
+                    self.token_info = CustomerTokenInfo(token_info)
+                    if self.token_listener is not None:
+                        self.token_listener.update_token(token_info)
+                else:
+                    logger.error("token refresh failed")
+            except Exception as e:
+                logger.error("token refresh failed: %s", e)
+            finally:
+                self._refreshing.active = False
 
     def get(self, path: str, params: dict[str, Any] | None = None, skip_token: bool = False) -> dict[str, Any]:
         """Http Get.


### PR DESCRIPTION
## What this fixes

Two bugs causing silent re-auth failures every ~2 hours:

**1. Reentrancy guard allows concurrent callers to proceed with a stale token**
The `self.refresh_token` boolean prevented duplicate refreshes but didn't block concurrent API calls. A group command switching multiple devices simultaneously would start one refresh and let all others proceed with the expired token → `sign invalid (-9999999)`. Fixed with `threading.Lock()` + `threading.local()` (the local flag handles the recursive call path `refresh → get → __request → refresh`).

**2. X-token included on the refresh call**
Including an expired access token as `X-token` on the refresh endpoint causes `sign invalid` on some server versions. Fixed via a `skip_token` parameter on `__request`/`get` — no shared state mutation.

## Other changes
- Refresh window widened to 30 min: fires before expiry rather than relying on the server accepting expired tokens across all regions
- X-token unconditionally omitted on refresh calls

## Credit
Threading solution independently derived and validated by @dpgh947 in [home-assistant/core#178281](https://github.com/home-assistant/core/issues/178281) — a long and valuable thread that shaped this entire PR.

## Related
- HA core PR [#178423](https://github.com/home-assistant/core/pull/178423): lower `setLevel(CRITICAL)` to `WARNING` in the Tuya integration