### PR TITLE
Parse electricity meter frame V0/V1/V2 into six parameters

### DIFF
--- a/tuya_sharing/strategy_repo/db_v1_params.py
+++ b/tuya_sharing/strategy_repo/db_v1_params.py
@@ -26,11 +26,39 @@ def decode4hex_str(input: str) -> str:
 
 
 def convert_value(s: str) -> str:
+    s = s.lower()
     vo = DBV1CircuitParamsVO()
-    vo.voltage = hex2decimal(s[0:4]) / 10.0
-    vo.electricCurrent = hex2decimal(s[4:10]) / 1000.0
-    vo.power = hex2decimal(s[10:16]) / 1000.0
-    return json.dumps(vo.__dict__)
+    if len(s) >= 34 and s.startswith("010f"):
+        # 帧 V1（头 010f，17 字节）
+        _parse_full(vo, s)
+    elif len(s) >= 36 and s.startswith("020f"):
+        # 帧 V2（头 020f，18 字节，末字节为符号位）
+        _parse_full(vo, s)
+        sign = hex2decimal(s[34:36])
+        if sign & 0x1:
+            vo.electricCurrent = -vo.electricCurrent
+        if sign & 0x2:
+            vo.power = -vo.power
+        if sign & 0x4:
+            vo.reactivePower = -vo.reactivePower
+        if sign & 0x8:
+            vo.powerFactor = -vo.powerFactor
+    else:
+        # 老帧（8 字节，无头，仅电压/电流/有功）
+        vo.voltage = hex2decimal(s[0:4]) / 10.0
+        vo.electricCurrent = hex2decimal(s[4:10]) / 1000.0
+        vo.power = hex2decimal(s[10:16]) / 1000.0
+    # 跳过 None：老帧仍只输出 3 字段，与升级前逐字节一致
+    return json.dumps({k: v for k, v in vo.__dict__.items() if v is not None})
+
+
+def _parse_full(vo: "DBV1CircuitParamsVO", s: str) -> None:
+    vo.voltage = hex2decimal(s[4:8]) / 10.0
+    vo.electricCurrent = hex2decimal(s[8:14]) / 1000.0
+    vo.power = hex2decimal(s[14:20]) / 1000.0
+    vo.reactivePower = hex2decimal(s[20:26]) / 1000.0
+    vo.apparentPower = hex2decimal(s[26:32]) / 1000.0
+    vo.powerFactor = hex2decimal(s[32:34]) / 100.0
 
 
 def hex2decimal(hex_str: str) -> int:
@@ -48,7 +76,13 @@ class DBV1CircuitParamsVO:
         voltage: Optional[float] = None,
         electric_current: Optional[float] = None,
         power: Optional[float] = None,
+        reactive_power: Optional[float] = None,
+        apparent_power: Optional[float] = None,
+        power_factor: Optional[float] = None,
     ):
         self.voltage = voltage
         self.electricCurrent = electric_current
         self.power = power
+        self.reactivePower = reactive_power
+        self.apparentPower = apparent_power
+        self.powerFactor = power_factor


### PR DESCRIPTION
## What

Upgrade the `db_v1_params` strategy so the electricity-meter phase frame is decoded by protocol version, extracting all six parameters: voltage, current, active power, reactive power, apparent power and power factor.

## Why

`convert_value` currently reads only the first 8 bytes as a legacy frame. For the newer **v01** (header `01 0F`) and **v02** (header `02 0F`) frames it misreads the 2-byte header as voltage — e.g. a v02 frame produces `voltage = 0x020F / 10 = 52.7 V` — and never decodes reactive power, apparent power or power factor.

The visible symptom: phase data is correct in the Tuya App but wrong once synced to Home Assistant (voltage shows ~52.7 V, and the automation trigger only exposes voltage/current/active power).

## How

- Detect the frame by length + header:
  - legacy: 8 bytes, no header — 3 params (unchanged);
  - v01: 17 bytes, header `01 0F` — 6 params;
  - v02: 18 bytes, header `02 0F` — 6 params + a trailing sign byte.
- For v01/v02, decode all six parameters from the 15-byte data region (voltage ÷10, current/powers ÷1000, power factor ÷100 — big-endian).
- For v02, apply the sign byte: bit0 current / bit1 active / bit2 reactive / bit3 power factor (1 = negative).
- The legacy 8-byte frame still emits only voltage/current/power; the three new fields stay `None` and are skipped by `json.dumps`, so existing devices are byte-for-byte unchanged.

The byte layout matches the reference decoder in `tuya-device-handlers` (`ElectricityData.from_bytes`).

## Validation

Decoded known v0/v1/v2 frames, including the v02 sign bits and the legacy backward-compatibility case. Example v02 frame `020F092E002EE0000AF00001F400092E6200` now decodes to 235.0 V / 12.0 A / 2.8 kW / 0.5 kvar / 2.35 kVA / 0.98 (previously 52.7 V). `ruff check` and `ruff format` pass.
